### PR TITLE
Update settings.ini to force timm==0.6.7

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -15,7 +15,7 @@ language = English
 custom_sidebar = True
 license = apache2
 status = 2
-requirements = fastai>=2.1.7 zarr>=2.0 tifffile==2022.4.8 scikit-image imageio ipywidgets openpyxl imagecodecs albumentations>=1.0.0 natsort>=7.1.1 numba>=0.52.0 opencv-python-headless>=4.1.1,<4.5.5 timm>=0.5.4
+requirements = fastai>=2.1.7 zarr>=2.0 tifffile==2022.4.8 scikit-image imageio ipywidgets openpyxl imagecodecs albumentations>=1.0.0 natsort>=7.1.1 numba>=0.52.0 opencv-python-headless>=4.1.1,<4.5.5 timm==0.6.7
 pip_requirements = segmentation-models-pytorch-deepflash2
 conda_requirements = segmentation_models_pytorch>=0.3.0
 nbs_path = nbs


### PR DESCRIPTION
installing with `pip install git+https://github.com/matjesg/deepflash2.git@master` fails when importing due to timm.

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[1], line 7
      4 #!pip install -Uqq deepflash2
      5 #!pip install git+https://github.com/matjesg/deepflash2.git@master
      6 import deepflash2
----> 7 from deepflash2.gui import GUI, _connect_to_drive
      8 clear_output(wait=True)
      9 display(HTML(f'Using deepflash2 version {deepflash2.__version__}'))

File /build/miniconda3/lib/python3.8/site-packages/deepflash2/gui.py:25
     23 from fastcore.basics import GetAttr
     24 from fastai.data.transforms import get_files
---> 25 import segmentation_models_pytorch as smp
     26 import matplotlib.pyplot as plt
     28 from .config import Config

File /build/miniconda3/lib/python3.8/site-packages/segmentation_models_pytorch/__init__.py:2
      1 from . import datasets
----> 2 from . import encoders
      3 from . import decoders
      4 from . import losses

File /build/miniconda3/lib/python3.8/site-packages/segmentation_models_pytorch/encoders/__init__.py:15
     13 from .mobilenet import mobilenet_encoders
     14 from .xception import xception_encoders
---> 15 from .timm_efficientnet import timm_efficientnet_encoders
     16 from .timm_resnest import timm_resnest_encoders
     17 from .timm_res2net import timm_res2net_encoders

File /build/miniconda3/lib/python3.8/site-packages/segmentation_models_pytorch/encoders/timm_efficientnet.py:8
      6 from timm.models.efficientnet import EfficientNet
      7 from timm.models.efficientnet import decode_arch_def, round_channels, default_cfgs
----> 8 from timm.models.layers.activations import Swish
     10 from ._base import EncoderMixin
     13 def get_efficientnet_kwargs(channel_multiplier=1.0, depth_multiplier=1.0, drop_rate=0.2):

ModuleNotFoundError: No module named 'timm.models.layers.activations'
```

Fixing  `timm==0.6.7` in settings.ini seems to solve this.